### PR TITLE
add ja.css

### DIFF
--- a/lang/ja.css
+++ b/lang/ja.css
@@ -1,0 +1,5 @@
+:lang(ja) .theorem::before { content: '定理 ' counter(theorem) '. ' !important; }
+:lang(ja) .theorem {font-style: italic; }
+:lang(ja) .lemma::before { content: '補題 ' counter(theorem) '. ' !important; }
+:lang(ja) .proof::before { content: '証明: ' attr(title) !important; font-style: normal;}
+:lang(ja) .definition::before { content: '定義 ' counter(definition) '. ' !important; }

--- a/lang/ja.css
+++ b/lang/ja.css
@@ -1,5 +1,5 @@
 :lang(ja) .theorem::before { content: '定理 ' counter(theorem) '. ' !important; }
-:lang(ja) .theorem {font-style: italic; }
+:lang(ja) .theorem { font-style: italic; }
 :lang(ja) .lemma::before { content: '補題 ' counter(theorem) '. ' !important; }
-:lang(ja) .proof::before { content: '証明: ' attr(title) !important; font-style: normal;}
+:lang(ja) .proof::before { content: '証明: ' attr(title) !important; font-style: normal; }
 :lang(ja) .definition::before { content: '定義 ' counter(definition) '. ' !important; }


### PR DESCRIPTION
Added Japanese translation in lang.
Note that 'font-style: normal;' added in two places, because we usually do not regularly use italics in Japanese texts.