### PR TITLE
chore: make embed stylesheet code stand out

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,8 +91,7 @@
       <ul>
         <li>
           Add
-          <code class="language-html">&lt;link rel="stylesheet"
-              href="https://latex.now.sh/style.css"&gt;</code>
+          <pre><code class="language-html">&lt;link rel="stylesheet" href="https://latex.now.sh/style.css"&gt;</code></pre>
           to the <code class="language-html">&lt;head&gt;</code> of your website or install the
           package using <code>npm install latex.css</code>.
         </li>


### PR DESCRIPTION
I was using this repo the other day and I missed your embed code for `style.css` but instead embedded `prism.css` as it is wrapped in `<pre>` and therefore stands out more (you can see this scene in [this video](https://youtu.be/Xl5jPSGEr_0?t=321)).

so... committed a minor change to make the embed code also stands out more.