### PR TITLE
fix counter-reset in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -141,9 +141,7 @@ body {
   margin: 0 auto;
   padding: 2rem 1.25rem;
 
-  counter-reset: theorem;
-  counter-reset: definition;
-  counter-reset: sidenote-counter;
+  counter-reset: theorem definition sidenote-counter;
 
   color: hsl(0, 5%, 10%);
   background-color: hsl(210, 20%, 98%);


### PR DESCRIPTION
Multiple `counter-reset` assignments for the same element overwrite each other and prevent some of the counters from being reset properly; this was fixed with this commit;