### PR TITLE
Tidy package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,8 @@
     "css"
   ],
   "homepage": "https://latex.now.sh",
-  "bugs": {
-    "url": "https://github.com/vincentdoerig/latex-css/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/vincentdoerig/latex-css.git"
-  },
+  "bugs": "https://github.com/vincentdoerig/latex-css/issues",
+  "repository": "github:vincentdoerig/latex-css",
   "license": "MIT",
   "author": "Vincent Dörig",
   "main": "./style.min.css",

--- a/package.json
+++ b/package.json
@@ -2,26 +2,26 @@
   "name": "latex.css",
   "version": "1.8.0",
   "description": "A small CSS library to make your website look like a LaTeX document",
-  "main": "./style.min.css",
-  "scripts": {
-    "build": "uglifycss style.css > style.min.css"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/vincentdoerig/latex-css.git"
-  },
   "keywords": [
     "latex",
     "latex-css",
     "classless-theme",
     "css"
   ],
-  "author": "Vincent Dörig",
-  "license": "MIT",
+  "homepage": "https://latex.now.sh",
   "bugs": {
     "url": "https://github.com/vincentdoerig/latex-css/issues"
   },
-  "homepage": "https://latex.now.sh",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vincentdoerig/latex-css.git"
+  },
+  "license": "MIT",
+  "author": "Vincent Dörig",
+  "main": "./style.min.css",
+  "scripts": {
+    "build": "uglifycss style.css > style.min.css"
+  },
   "devDependencies": {
     "uglifycss": "0.0.29"
   }


### PR DESCRIPTION
This PR would...
- Use [sort-package-json](https://www.npmjs.com/package/sort-package-json) to sort it (used [VS Code extension](https://marketplace.visualstudio.com/items?itemName=unional.vscode-sort-package-json))
- Edit the `bugs` and `repository` to be one-liners instead of objects
- **NOT** change from `main` to `exports`

Changing from `main` to `exports` is the new way that package.json is leaning towards. That and `type: "module"`. Using these in the future would probably be a good idea.