### PR TITLE
feat: add custom table borders and column alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,18 +480,19 @@
         col-7-c col-8-c">
         <caption>Example table with custom borders and aligment</caption>
         <colgroup>
-          <col class="border-right-thin">
-          <col class="border-right-thin">
-          <col class="border-right-thin">
+          <col class="border-left-thin border-right-thin">
           <col class="border-right-thin">
           <col class="border-right-thin">
           <col class="border-right-thin">
           <col class="border-right-thick">
-          <col>
+          <col class="border-right-thin">
+          <col class="border-right-thin">
         </colgroup>
+        <tr class="border-top-thin">
+          <th scope="col" colspan="7">De Morgan's Law: $\lnot P \lor \lnot Q \iff \lnot (P \land Q)$</th>
+        </tr>
         <tr>
-          <th scope="col" colspan="7"></th>
-          <th>DeMorgan's Law</th>
+          <th scope="col" colspan="7" class="border-bottom-thin">TRUTH TABLE</th>
         </tr>
         <tr class="border-bottom-thin">
           <td>$P$</td>
@@ -501,7 +502,6 @@
           <td>$P \land Q$</td>
           <td>$\lnot P \lor \lnot Q$</td>
           <td>$\lnot (P \land Q)$</td>
-          <td>$\lnot P \lor \lnot Q \iff \lnot (P \land Q)$</td>
         </tr>
         <tr class="border-bottom-thin">
           <td rowspan="2">T</td>
@@ -509,17 +509,15 @@
           <td rowspan="2">F</td>
           <td>F</td>
           <td>T</td>
-          <td>F</td>
-          <td>F</td>
-          <td>T</td>
+          <td><strong>F</strong></td>
+          <td><strong>F</strong></td>
         </tr>
         <tr class="border-bottom-thin">
           <td>F</td>
           <td>T</td>
           <td>F</td>
-          <td>T</td>
-          <td>T</td>
-          <td>T</td>
+          <td><strong>T</strong></td>
+          <td><strong>T</strong></td>
         </tr>
         <tr class="border-bottom-thin">
           <td rowspan="2">F</td>
@@ -527,17 +525,15 @@
           <td rowspan="2">T</td>
           <td>F</td>
           <td>F</td>
-          <td>T</td>
-          <td>T</td>
-          <td>T</td>
+          <td><strong>T</strong></td>
+          <td><strong>T</strong></td>
         </tr>
-        <tr>
+        <tr class="border-bottom-thin">
           <td>F</td>
           <td>T</td>
           <td>F</td>
-          <td>T</td>
-          <td>T</td>
-          <td>T</td>
+          <td><strong>T</strong></td>
+          <td><strong>T</strong></td>
         </tr>
       </table>
 

--- a/index.html
+++ b/index.html
@@ -231,11 +231,11 @@
       <h4 id="table-column-aligment">Table column alignment</h4>
       <p>
         For each column of the table, there is one class for left, center or right
-        alignment, up to 12 columns: <code>l1-l12</code>, <code>c1-c12</code>,
-        <code>r1-r12</code>. For example, a table with 3 columns using the following
-        classes
+        alignment, up to 12 columns: <code>col-n-l</code>, <code>col-n-c</code>,
+        <code>col-n-r</code>, <code>n</code>=1, ...,12. For example, a table with 3 columns
+        using the following classes
       </p>
-      <pre><code class="language-html">&lt;table class="l1 c2 r3"&gt;
+      <pre><code class="language-html">&lt;table class="col-1-l col-2-c col-3-r"&gt;
   &lt;tr&gt;
     &lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;
   &lt;/tr&gt;
@@ -476,7 +476,8 @@
         </table>
       </div>
 
-      <table class="borders-custom c1 c2 c3 c4 c5 c6 c7 c8">
+      <table class="borders-custom col-1-c col-2-c col-3-c col-4-c col-5-c col-6-c
+        col-7-c col-8-c">
         <caption>Example table with custom borders and aligment</caption>
         <colgroup>
           <col class="border-right-thin">
@@ -540,7 +541,7 @@
         </tr>
       </table>
 
-      <table class="borders-custom l1 c2 c3 r4">
+      <table class="borders-custom col-1-l col-2-c col-3-c col-4-r">
         <caption>Close approaches to the Earth by NEOs</caption>
         <thead>
           <tr class="border-bottom-thick">

--- a/index.html
+++ b/index.html
@@ -213,17 +213,17 @@
       <h4 id="table-borders">Custom table borders</h4>
       <p>
         To add custom borders to the table, you should use the class
-        <code class="language-html">.custom-borders</code> with <code>&lt;table&gt;</code>
+        <code class="language-html">borders-custom</code> with <code>&lt;table&gt;</code>
         tag, to begin with a table without any border. The classes 
-        <code>border-&lt;position&gt;</code> and <code>heavy-border-&lt;position&gt;</code>,
+        <code>border-&lt;position&gt;-thin</code> and <code>border-&lt;position&gt;-thick</code>,
         are available, where <code>&lt;position&gt;</code> can take one of the values:
         <code>top</code>, <code>right</code>, <code>bottom</code>, <code>left</code>.
       </p>
-      <pre><code class="language-html">&lt;table class="custom-borders ..."&gt;
-  &lt;tr class="border-bottom"&gt;
+      <pre><code class="language-html">&lt;table class="borders-custom ..."&gt;
+  &lt;tr class="border-bottom-thick"&gt;
     &lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;
   &lt;/tr&gt;
-  &lt;tr class="border-bottom"&gt;
+  &lt;tr class="border-bottom-thin"&gt;
     &lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;
   &lt;/tr&gt;
   ...</code></pre>
@@ -476,23 +476,23 @@
         </table>
       </div>
 
-      <table class="custom-borders c1 c2 c3 c4 c5 c6 c7 c8">
+      <table class="borders-custom c1 c2 c3 c4 c5 c6 c7 c8">
         <caption>Example table with custom borders and aligment</caption>
         <colgroup>
-          <col class="border-right">
-          <col class="border-right">
-          <col class="border-right">
-          <col class="border-right">
-          <col class="border-right">
-          <col class="border-right">
-          <col class="heavy-border-right">
+          <col class="border-right-thin">
+          <col class="border-right-thin">
+          <col class="border-right-thin">
+          <col class="border-right-thin">
+          <col class="border-right-thin">
+          <col class="border-right-thin">
+          <col class="border-right-thick">
           <col>
         </colgroup>
         <tr>
           <th scope="col" colspan="7"></th>
           <th>DeMorgan's Law</th>
         </tr>
-        <tr class="border-bottom">
+        <tr class="border-bottom-thin">
           <td>$P$</td>
           <td>$Q$</td>
           <td>$\lnot P$</td>
@@ -502,7 +502,7 @@
           <td>$\lnot (P \land Q)$</td>
           <td>$\lnot P \lor \lnot Q \iff \lnot (P \land Q)$</td>
         </tr>
-        <tr class="border-bottom">
+        <tr class="border-bottom-thin">
           <td rowspan="2">T</td>
           <td>T</td>
           <td rowspan="2">F</td>
@@ -512,7 +512,7 @@
           <td>F</td>
           <td>T</td>
         </tr>
-        <tr class="border-bottom">
+        <tr class="border-bottom-thin">
           <td>F</td>
           <td>T</td>
           <td>F</td>
@@ -520,7 +520,7 @@
           <td>T</td>
           <td>T</td>
         </tr>
-        <tr class="border-bottom">
+        <tr class="border-bottom-thin">
           <td rowspan="2">F</td>
           <td>T</td>
           <td rowspan="2">T</td>
@@ -540,10 +540,10 @@
         </tr>
       </table>
 
-      <table class="custom-borders l1 c2 c3 r4">
+      <table class="borders-custom l1 c2 c3 r4">
         <caption>Close approaches to the Earth by NEOs</caption>
         <thead>
-          <tr class="heavy-border-bottom">
+          <tr class="border-bottom-thick">
             <th>CA Date</th>
             <th>Object Name</th>
             <th>Diameter</th>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,12 @@
             </ol>
           </li>
           <li><a href="#paragraphs">Paragraphs</a></li>
+          <li><a href="#table-classes">Table classes</a>
+            <ol>
+              <li><a href="#table-borders">Custom table borders</a></li>
+              <li><a href="#table-column-aligment">Table column alignment</a></li>
+            </ol>
+          </li>
         </ol>
       </li>
       <li><a href="#language-support">Language Support</a></li>
@@ -203,6 +209,43 @@
         To avoid first line indentation of some specific paragraph, the class <code>no-indent</code>
         can be used.</p>
       <pre><code class="language-html">&lt;p class="no-indent"&gt;...&lt;/p&gt;</code></pre>
+      <h3 id="table-classes">Table classes</h3>
+      <h4 id="table-borders">Custom table borders</h4>
+      <p>
+        To add custom borders to the table, you should use the class
+        <code class="language-html">.custom-borders</code> with <code>&lt;table&gt;</code>
+        tag, to begin with a table without any border. The classes 
+        <code>border-&lt;position&gt;</code> and <code>heavy-border-&lt;position&gt;</code>,
+        are available, where <code>&lt;position&gt;</code> can take one of the values:
+        <code>top</code>, <code>right</code>, <code>bottom</code>, <code>left</code>.
+      </p>
+      <pre><code class="language-html">&lt;table class="custom-borders ..."&gt;
+  &lt;tr class="border-bottom"&gt;
+    &lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;
+  &lt;/tr&gt;
+  &lt;tr class="border-bottom"&gt;
+    &lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;
+  &lt;/tr&gt;
+  ...</code></pre>
+      <p>See full examples in <a href="#tables">section about tables</a>.</p>
+      <h4 id="table-column-aligment">Table column alignment</h4>
+      <p>
+        For each column of the table, there is one class for left, center or right
+        alignment, up to 12 columns: <code>l1-l12</code>, <code>c1-c12</code>,
+        <code>r1-r12</code>. For example, a table with 3 columns using the following
+        classes
+      </p>
+      <pre><code class="language-html">&lt;table class="l1 c2 r3"&gt;
+  &lt;tr&gt;
+    &lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;&lt;td&gt;...&lt;/td&gt;
+  &lt;/tr&gt;
+  ...</code></pre>
+      <p>
+        aligns to the left the first column, centers the second one and aligns to the
+        right the third of the columns.
+      </p>
+
+      <p>See full examples in <a href="#tables">section about tables</a>.</p>
 
       <h2 id="language-support">Language Support</h2>
       <p>
@@ -432,6 +475,127 @@
           </tbody>
         </table>
       </div>
+
+      <table class="custom-borders c1 c2 c3 c4 c5 c6 c7 c8">
+        <caption>Example table with custom borders and aligment</caption>
+        <colgroup>
+          <col class="border-right">
+          <col class="border-right">
+          <col class="border-right">
+          <col class="border-right">
+          <col class="border-right">
+          <col class="border-right">
+          <col class="heavy-border-right">
+          <col>
+        </colgroup>
+        <tr>
+          <th scope="col" colspan="7"></th>
+          <th>DeMorgan's Law</th>
+        </tr>
+        <tr class="border-bottom">
+          <td>$P$</td>
+          <td>$Q$</td>
+          <td>$\lnot P$</td>
+          <td>$\lnot Q$</td>
+          <td>$P \land Q$</td>
+          <td>$\lnot P \lor \lnot Q$</td>
+          <td>$\lnot (P \land Q)$</td>
+          <td>$\lnot P \lor \lnot Q \iff \lnot (P \land Q)$</td>
+        </tr>
+        <tr class="border-bottom">
+          <td rowspan="2">T</td>
+          <td>T</td>
+          <td rowspan="2">F</td>
+          <td>F</td>
+          <td>T</td>
+          <td>F</td>
+          <td>F</td>
+          <td>T</td>
+        </tr>
+        <tr class="border-bottom">
+          <td>F</td>
+          <td>T</td>
+          <td>F</td>
+          <td>T</td>
+          <td>T</td>
+          <td>T</td>
+        </tr>
+        <tr class="border-bottom">
+          <td rowspan="2">F</td>
+          <td>T</td>
+          <td rowspan="2">T</td>
+          <td>F</td>
+          <td>F</td>
+          <td>T</td>
+          <td>T</td>
+          <td>T</td>
+        </tr>
+        <tr>
+          <td>F</td>
+          <td>T</td>
+          <td>F</td>
+          <td>T</td>
+          <td>T</td>
+          <td>T</td>
+        </tr>
+      </table>
+
+      <table class="custom-borders l1 c2 c3 r4">
+        <caption>Close approaches to the Earth by NEOs</caption>
+        <thead>
+          <tr class="heavy-border-bottom">
+            <th>CA Date</th>
+            <th>Object Name</th>
+            <th>Diameter</th>
+            <th>Dist. Min. (LD)</th>
+          </tr>
+        </thead>
+          <tbody>
+            <tr>
+              <td>2023-Jul-10</td>
+              <td>2018 NW</td>
+              <td>7.3m-16m</td>
+              <td>0.287</td>
+            </tr>
+            <tr>
+              <td>2023-Jul-10</td>
+              <td>2023 LN1</td>
+              <td>45m-00m</td>
+              <td>17.813</td>
+            </tr>
+            <tr>
+              <td>2023-Jul-11</td>
+              <td>2023 MD2</td>
+              <td>36m-80m</td>
+              <td>5.570</td>
+            </tr>
+            <tr>
+              <td>2023-Jul-11</td>
+              <td>2023 NE</td>
+              <td>32m-70m</td>
+              <td>11.253</td>
+            </tr>
+            <tr>
+              <td>2023-Jul-11</td>
+              <td>2023 MQ1</td>
+              <td>28m-62m</td>
+              <td>10.716</td>
+            </tr>
+            <tr>
+              <td>2023-Jul-12</td>
+              <td>2023 OM</td>
+              <td>20m-46m</td>
+              <td>7.628</td>
+            </tr>
+            <tr>
+              <td>2023-Jul-12</td>
+              <td>2018 UY</td>
+              <td>190m-420m</td>
+              <td>7.412</td>
+            </tr>
+          </tbody>
+        <tr></tr>
+      </table>
 
       <h3 id="images">Images</h3>
       <figure>

--- a/index.html
+++ b/index.html
@@ -550,51 +550,50 @@
             <th>Dist. Min. (LD)</th>
           </tr>
         </thead>
-          <tbody>
-            <tr>
-              <td>2023-Jul-10</td>
-              <td>2018 NW</td>
-              <td>7.3m-16m</td>
-              <td>0.287</td>
-            </tr>
-            <tr>
-              <td>2023-Jul-10</td>
-              <td>2023 LN1</td>
-              <td>45m-00m</td>
-              <td>17.813</td>
-            </tr>
-            <tr>
-              <td>2023-Jul-11</td>
-              <td>2023 MD2</td>
-              <td>36m-80m</td>
-              <td>5.570</td>
-            </tr>
-            <tr>
-              <td>2023-Jul-11</td>
-              <td>2023 NE</td>
-              <td>32m-70m</td>
-              <td>11.253</td>
-            </tr>
-            <tr>
-              <td>2023-Jul-11</td>
-              <td>2023 MQ1</td>
-              <td>28m-62m</td>
-              <td>10.716</td>
-            </tr>
-            <tr>
-              <td>2023-Jul-12</td>
-              <td>2023 OM</td>
-              <td>20m-46m</td>
-              <td>7.628</td>
-            </tr>
-            <tr>
-              <td>2023-Jul-12</td>
-              <td>2018 UY</td>
-              <td>190m-420m</td>
-              <td>7.412</td>
-            </tr>
-          </tbody>
-        <tr></tr>
+        <tbody>
+          <tr>
+            <td>2023-Jul-10</td>
+            <td>2018 NW</td>
+            <td>7.3m-16m</td>
+            <td>0.287</td>
+          </tr>
+          <tr>
+            <td>2023-Jul-10</td>
+            <td>2023 LN1</td>
+            <td>45m-00m</td>
+            <td>17.813</td>
+          </tr>
+          <tr>
+            <td>2023-Jul-11</td>
+            <td>2023 MD2</td>
+            <td>36m-80m</td>
+            <td>5.570</td>
+          </tr>
+          <tr>
+            <td>2023-Jul-11</td>
+            <td>2023 NE</td>
+            <td>32m-70m</td>
+            <td>11.253</td>
+          </tr>
+          <tr>
+            <td>2023-Jul-11</td>
+            <td>2023 MQ1</td>
+            <td>28m-62m</td>
+            <td>10.716</td>
+          </tr>
+          <tr>
+            <td>2023-Jul-12</td>
+            <td>2023 OM</td>
+            <td>20m-46m</td>
+            <td>7.628</td>
+          </tr>
+          <tr>
+            <td>2023-Jul-12</td>
+            <td>2018 UY</td>
+            <td>190m-420m</td>
+            <td>7.412</td>
+          </tr>
+        </tbody>
       </table>
 
       <h3 id="images">Images</h3>

--- a/style.css
+++ b/style.css
@@ -365,7 +365,7 @@ table.borders-custom {
   border-spacing: 0;
   width: auto;
   max-width: 100%;
-  overflow-x: auto; /* does not work because element is not block */
+  overflow-x: auto;
   counter-increment: caption;
 }
 

--- a/style.css
+++ b/style.css
@@ -109,8 +109,8 @@
   --kbd-bg-color: hsl(210, 5%, 100%);
   --kbd-border-color: hsl(210, 5%, 70%);
   --table-border-color: black;
-  --light-rule-width: 1.36px;
-  --heavy-rule-width: 2.27px;
+  --border-width-thin: 1.36px;
+  --border-width-thick: 2.27px;
   --sidenote-target-border-color: hsl(55, 55%, 70%);
   --footnotes-border-color: hsl(0, 0%, 39%);
   --text-indent-size: 1.463rem; /* In 12pt [Latin Modern font] LaTeX article
@@ -298,7 +298,7 @@ kbd {
 }
 
 /* Better tables */
-table:not(.custom-borders) {
+table:not(.borders-custom) {
   border-collapse: collapse;
   border-spacing: 0;
   width: auto;
@@ -311,19 +311,19 @@ table:not(.custom-borders) {
   counter-increment: caption;
 }
 /* add bottom border on column table headings  */
-table:not(.custom-borders) tr > th[scope='col'] {
+table:not(.borders-custom) tr > th[scope='col'] {
   border-bottom: 1.36px solid var(--table-border-color);
 }
 /* add right border on row table headings  */
-table:not(.custom-borders) tr > th[scope='row'] {
+table:not(.borders-custom) tr > th[scope='row'] {
   border-right: 1.36px solid var(--table-border-color);
 }
-table:not(.custom-borders) > tbody > tr:first-child > td,
-table:not(.custom-borders) > tbody > tr:first-child > th {
+table:not(.borders-custom) > tbody > tr:first-child > td,
+table:not(.borders-custom) > tbody > tr:first-child > th {
   border-top: 1.36px solid var(--table-border-color);
 }
-table:not(.custom-borders) > tbody > tr:last-child > td,
-table:not(.custom-borders) > tbody > tr:last-child > th {
+table:not(.borders-custom) > tbody > tr:last-child > td,
+table:not(.borders-custom) > tbody > tr:last-child > th {
   border-bottom: 1.36px solid var(--table-border-color);
 }
 
@@ -360,7 +360,7 @@ caption::before {
 }
 
 /* Table custom borders */
-table.custom-borders {
+table.borders-custom {
   border-collapse: collapse;
   border-spacing: 0;
   width: auto;
@@ -369,30 +369,30 @@ table.custom-borders {
   counter-increment: caption;
 }
 
-.heavy-border-top {
-  border-top: var(--heavy-rule-width) solid var(--table-border-color);
+.border-top-thick {
+  border-top: var(--border-width-thick) solid var(--table-border-color);
 }
-.heavy-border-right {
-  border-right: var(--heavy-rule-width) solid var(--table-border-color);
+.border-right-thick {
+  border-right: var(--border-width-thick) solid var(--table-border-color);
 }
-.heavy-border-bottom {
-  border-bottom: var(--heavy-rule-width) solid var(--table-border-color);
+.border-bottom-thick {
+  border-bottom: var(--border-width-thick) solid var(--table-border-color);
 }
-.heavy-border-left {
-  border-left: var(--heavy-rule-width) solid var(--table-border-color);
+.border-left-thick {
+  border-left: var(--border-width-thick) solid var(--table-border-color);
 }
 
-.border-top {
-  border-top: var(--light-rule-width) solid var(--table-border-color);
+.border-top-thin {
+  border-top: var(--border-width-thin) solid var(--table-border-color);
 }
-.border-right {
-  border-right: var(--light-rule-width) solid var(--table-border-color);
+.border-right-thin {
+  border-right: var(--border-width-thin) solid var(--table-border-color);
 }
-.border-bottom {
-  border-bottom: var(--light-rule-width) solid var(--table-border-color);
+.border-bottom-thin {
+  border-bottom: var(--border-width-thin) solid var(--table-border-color);
 }
-.border-left {
-  border-left: var(--light-rule-width) solid var(--table-border-color);
+.border-left-thin {
+  border-left: var(--border-width-thin) solid var(--table-border-color);
 }
 
 /* Table column alignment */

--- a/style.css
+++ b/style.css
@@ -303,8 +303,8 @@ table:not(.borders-custom) {
   border-spacing: 0;
   width: auto;
   max-width: 100%;
-  border-top: 2.27px solid var(--table-border-color);
-  border-bottom: 2.27px solid var(--table-border-color);
+  border-top: var(--border-width-thick) solid var(--table-border-color);
+  border-bottom: var(--border-width-thick) solid var(--table-border-color);
   /* display: block; */
   overflow-x: auto; /* does not work because element is not block */
   /* white-space: nowrap; */
@@ -312,19 +312,19 @@ table:not(.borders-custom) {
 }
 /* add bottom border on column table headings  */
 table:not(.borders-custom) tr > th[scope='col'] {
-  border-bottom: 1.36px solid var(--table-border-color);
+  border-bottom: var(--border-width-thin) solid var(--table-border-color);
 }
 /* add right border on row table headings  */
 table:not(.borders-custom) tr > th[scope='row'] {
-  border-right: 1.36px solid var(--table-border-color);
+  border-right: var(--border-width-thin) solid var(--table-border-color);
 }
 table:not(.borders-custom) > tbody > tr:first-child > td,
 table:not(.borders-custom) > tbody > tr:first-child > th {
-  border-top: 1.36px solid var(--table-border-color);
+  border-top: var(--border-width-thin) solid var(--table-border-color);
 }
 table:not(.borders-custom) > tbody > tr:last-child > td,
 table:not(.borders-custom) > tbody > tr:last-child > th {
-  border-bottom: 1.36px solid var(--table-border-color);
+  border-bottom: var(--border-width-thin) solid var(--table-border-color);
 }
 
 th,

--- a/style.css
+++ b/style.css
@@ -396,46 +396,46 @@ table.borders-custom {
 }
 
 /* Table column alignment */
-.l1 tr > :nth-child(1),
-.l2 tr > :nth-child(2),
-.l3 tr > :nth-child(3),
-.l4 tr > :nth-child(4),
-.l5 tr > :nth-child(5),
-.l6 tr > :nth-child(6),
-.l7 tr > :nth-child(7),
-.l8 tr > :nth-child(8),
-.l9 tr > :nth-child(9),
-.l10 tr > :nth-child(10),
-.l11 tr > :nth-child(11),
-.l12 tr > :nth-child(12) {
+.col-1-l tr > :nth-child(1),
+.col-2-l tr > :nth-child(2),
+.col-3-l tr > :nth-child(3),
+.col-4-l tr > :nth-child(4),
+.col-5-l tr > :nth-child(5),
+.col-6-l tr > :nth-child(6),
+.col-7-l tr > :nth-child(7),
+.col-8-l tr > :nth-child(8),
+.col-9-l tr > :nth-child(9),
+.col-10-l tr > :nth-child(10),
+.col-11-l tr > :nth-child(11),
+.col-12-l tr > :nth-child(12) {
   text-align: left;
 }
-.c1 tr > :nth-child(1),
-.c2 tr > :nth-child(2),
-.c3 tr > :nth-child(3),
-.c4 tr > :nth-child(4),
-.c5 tr > :nth-child(5),
-.c6 tr > :nth-child(6),
-.c7 tr > :nth-child(7),
-.c8 tr > :nth-child(8),
-.c9 tr > :nth-child(9),
-.c10 tr > :nth-child(10),
-.c11 tr > :nth-child(11),
-.c12 tr > :nth-child(12) {
+.col-1-c tr > :nth-child(1),
+.col-2-c tr > :nth-child(2),
+.col-3-c tr > :nth-child(3),
+.col-4-c tr > :nth-child(4),
+.col-5-c tr > :nth-child(5),
+.col-6-c tr > :nth-child(6),
+.col-7-c tr > :nth-child(7),
+.col-8-c tr > :nth-child(8),
+.col-9-c tr > :nth-child(9),
+.col-10-c tr > :nth-child(10),
+.col-11-c tr > :nth-child(11),
+.col-12-c tr > :nth-child(12) {
   text-align: center;
 }
-.r1 tr > :nth-child(1),
-.r2 tr > :nth-child(2),
-.r3 tr > :nth-child(3),
-.r4 tr > :nth-child(4),
-.r5 tr > :nth-child(5),
-.r6 tr > :nth-child(6),
-.r7 tr > :nth-child(7),
-.r8 tr > :nth-child(8),
-.r9 tr > :nth-child(9),
-.r10 tr > :nth-child(10),
-.r11 tr > :nth-child(11),
-.r12 tr > :nth-child(12) {
+.col-1-r tr > :nth-child(1),
+.col-2-r tr > :nth-child(2),
+.col-3-r tr > :nth-child(3),
+.col-4-r tr > :nth-child(4),
+.col-5-r tr > :nth-child(5),
+.col-6-r tr > :nth-child(6),
+.col-7-r tr > :nth-child(7),
+.col-8-r tr > :nth-child(8),
+.col-9-r tr > :nth-child(9),
+.col-10-r tr > :nth-child(10),
+.col-11-r tr > :nth-child(11),
+.col-12-r tr > :nth-child(12) {
   text-align: right;
 }
 

--- a/style.css
+++ b/style.css
@@ -109,6 +109,8 @@
   --kbd-bg-color: hsl(210, 5%, 100%);
   --kbd-border-color: hsl(210, 5%, 70%);
   --table-border-color: black;
+  --light-rule-width: 1.36px;
+  --heavy-rule-width: 2.27px;
   --sidenote-target-border-color: hsl(55, 55%, 70%);
   --footnotes-border-color: hsl(0, 0%, 39%);
   --text-indent-size: 1.463rem; /* In 12pt [Latin Modern font] LaTeX article
@@ -296,7 +298,7 @@ kbd {
 }
 
 /* Better tables */
-table {
+table:not(.custom-borders) {
   border-collapse: collapse;
   border-spacing: 0;
   width: auto;
@@ -309,19 +311,19 @@ table {
   counter-increment: caption;
 }
 /* add bottom border on column table headings  */
-table tr > th[scope='col'] {
+table:not(.custom-borders) tr > th[scope='col'] {
   border-bottom: 1.36px solid var(--table-border-color);
 }
 /* add right border on row table headings  */
-table tr > th[scope='row'] {
+table:not(.custom-borders) tr > th[scope='row'] {
   border-right: 1.36px solid var(--table-border-color);
 }
-table > tbody > tr:first-child > td,
-table > tbody > tr:first-child > th {
+table:not(.custom-borders) > tbody > tr:first-child > td,
+table:not(.custom-borders) > tbody > tr:first-child > th {
   border-top: 1.36px solid var(--table-border-color);
 }
-table > tbody > tr:last-child > td,
-table > tbody > tr:last-child > th {
+table:not(.custom-borders) > tbody > tr:last-child > td,
+table:not(.custom-borders) > tbody > tr:last-child > th {
   border-bottom: 1.36px solid var(--table-border-color);
 }
 
@@ -355,6 +357,86 @@ caption::before {
   the table cells shouldn't wrap */
 .scroll-wrapper > table td {
   white-space: nowrap;
+}
+
+/* Table custom borders */
+table.custom-borders {
+  border-collapse: collapse;
+  border-spacing: 0;
+  width: auto;
+  max-width: 100%;
+  overflow-x: auto; /* does not work because element is not block */
+  counter-increment: caption;
+}
+
+.heavy-border-top {
+  border-top: var(--heavy-rule-width) solid var(--table-border-color);
+}
+.heavy-border-right {
+  border-right: var(--heavy-rule-width) solid var(--table-border-color);
+}
+.heavy-border-bottom {
+  border-bottom: var(--heavy-rule-width) solid var(--table-border-color);
+}
+.heavy-border-left {
+  border-left: var(--heavy-rule-width) solid var(--table-border-color);
+}
+
+.border-top {
+  border-top: var(--light-rule-width) solid var(--table-border-color);
+}
+.border-right {
+  border-right: var(--light-rule-width) solid var(--table-border-color);
+}
+.border-bottom {
+  border-bottom: var(--light-rule-width) solid var(--table-border-color);
+}
+.border-left {
+  border-left: var(--light-rule-width) solid var(--table-border-color);
+}
+
+/* Table column alignment */
+.l1 tr > :nth-child(1),
+.l2 tr > :nth-child(2),
+.l3 tr > :nth-child(3),
+.l4 tr > :nth-child(4),
+.l5 tr > :nth-child(5),
+.l6 tr > :nth-child(6),
+.l7 tr > :nth-child(7),
+.l8 tr > :nth-child(8),
+.l9 tr > :nth-child(9),
+.l10 tr > :nth-child(10),
+.l11 tr > :nth-child(11),
+.l12 tr > :nth-child(12) {
+  text-align: left;
+}
+.c1 tr > :nth-child(1),
+.c2 tr > :nth-child(2),
+.c3 tr > :nth-child(3),
+.c4 tr > :nth-child(4),
+.c5 tr > :nth-child(5),
+.c6 tr > :nth-child(6),
+.c7 tr > :nth-child(7),
+.c8 tr > :nth-child(8),
+.c9 tr > :nth-child(9),
+.c10 tr > :nth-child(10),
+.c11 tr > :nth-child(11),
+.c12 tr > :nth-child(12) {
+  text-align: center;
+}
+.r1 tr > :nth-child(1),
+.r2 tr > :nth-child(2),
+.r3 tr > :nth-child(3),
+.r4 tr > :nth-child(4),
+.r5 tr > :nth-child(5),
+.r6 tr > :nth-child(6),
+.r7 tr > :nth-child(7),
+.r8 tr > :nth-child(8),
+.r9 tr > :nth-child(9),
+.r10 tr > :nth-child(10),
+.r11 tr > :nth-child(11),
+.r12 tr > :nth-child(12) {
+  text-align: right;
 }
 
 /* Center align the title */


### PR DESCRIPTION
Allow some few customization options for table borders and column alignment.

- For custom borders: adds classes `border-<position>` and `heavy-border-<position>`, being `position` one of the values, `top`, `right`, `bottom`, `left`.

- For custom column alignment: adds classes `l1-l12`, `c1-c12`, `r1-r12`.