### PR TITLE
fix: avoid unwanted extra hyphens in code fragments

### DIFF
--- a/style.css
+++ b/style.css
@@ -277,6 +277,7 @@ kbd {
   font-family: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
   font-size: 85%;
+  hyphens: none;
 }
 pre {
   padding: 1rem 1.4rem;


### PR DESCRIPTION

![unwanted-code-hyphen](https://github.com/vincentdoerig/latex-css/assets/60484272/6dce7a0f-1700-401d-8493-8b50b1a1e164)

This is the same value used by Prism.css, so it shouldn't change in case you use Prism and invert the loading order of the CSS files.