### PR TITLE
Correctly translate table captions in Czech

### DIFF
--- a/lang/cs.css
+++ b/lang/cs.css
@@ -2,3 +2,4 @@
 :lang(cs) .lemma::before { content: 'Lemma ' counter(theorem) '. ' !important; }
 :lang(cs) .proof::before { content: 'Důkaz. ' attr(title) !important; }
 :lang(cs) .definition::before { content: 'Definice ' counter(definition) '. ' !important; }
+:lang(cs) caption::before { content: 'Tabulka ' counter(caption) '. ' !important; }


### PR DESCRIPTION
Adds missing translation for table caption in Czech language.

I can't really help with this issue in other languages, sorry :disappointed:

**Before**  
![image](https://github.com/vincentdoerig/latex-css/assets/15214494/8600f181-2ab7-4d82-b536-adfc17aa1ff6)


**After**  
![image](https://github.com/vincentdoerig/latex-css/assets/15214494/5a72d39f-b042-4d2e-b485-a9b5536964cc)
