### PR TITLE
fix: replace old one-colon pseudo-element syntax

### DIFF
--- a/style.css
+++ b/style.css
@@ -453,7 +453,7 @@ nav ol {
 nav li {
   display: block;
 }
-nav li:before {
+nav li::before {
   content: counters(item, '.') ' ';
   counter-increment: item;
   padding-right: 0.85rem;
@@ -501,7 +501,7 @@ dl dd {
   content: 'Proof. ' attr(title);
   font-style: italic;
 }
-.proof:after {
+.proof::after {
   content: '◾️';
   filter: var(--proof-symbol-filter);
   position: absolute;


### PR DESCRIPTION
Replace old one-colon pseudo-element syntax.

Old one-colon pseudo element syntax is already set to be deprecated in 'Selectors Level 4' working draft:

- https://www.w3.org/TR/selectors-4/#pseudo-element-syntax