### PR TITLE
fix: replace unsupported image placeholder service

### DIFF
--- a/elements.html
+++ b/elements.html
@@ -287,14 +287,14 @@
           </header>
           <div>
             <h3>No <code>&lt;figure&gt;</code> element</h3>
-            <p><img src="https://source.unsplash.com/random/1000x600" alt="Image alt text" width="750" height="400">
+            <p><img src="https://picsum.photos/seed/elems-1/1000/600" alt="Image alt text" width="750" height="400">
             </p>
             <h3>Wrapped in a <code>&lt;figure&gt;</code> element, no <code>&lt;figcaption&gt;</code></h3>
-            <figure><img src="https://source.unsplash.com/random/600x400?sig=1" alt="Image alt text" width="600"
+            <figure><img src="https://picsum.photos/seed/elems-2/600/400" alt="Image alt text" width="600"
                 height="400"></figure>
             <h3>Wrapped in a <code>&lt;figure&gt;</code> element, with a <code>&lt;figcaption&gt;</code></h3>
             <figure>
-              <img src="https://source.unsplash.com/random/600x800?sig=2" alt="Image alt text" width="600" height="800">
+              <img src="https://picsum.photos/seed/elems-3/600/800" alt="Image alt text" width="600" height="800">
               <figcaption>Here is a caption for this image.</figcaption>
             </figure>
           </div>


### PR DESCRIPTION
Replace "unsplash" (https://unsplash.com) with "picsum" (https://picsum.photos) for random placeholder images, because "unsplash sources" has been finally turned off(*).

(*) https://unsplash.com/documentation/changelog#unsplash-source-sunset