### PR TITLE
fix: use a more specific CSS selector for navigation numbered lists

### DIFF
--- a/style.css
+++ b/style.css
@@ -466,10 +466,10 @@ nav ol {
   counter-reset: item;
   padding-left: 2rem;
 }
-nav li {
+nav ol > li {
   display: block;
 }
-nav li::before {
+nav ol > li::before {
   content: counters(item, '.') ' ';
   counter-increment: item;
   padding-right: 0.85rem;


### PR DESCRIPTION
Unordered lists inside `nav` elements are wrongly numbered ([https://latex.vercel.app/elements]()).

![Screenshot 2024-12-21 at 12-17-12 HTML5 Test Page](https://github.com/user-attachments/assets/d577a336-37bb-4f5f-9428-6ca92bedd206)

And it doesn't make much sense to not allow unordered lists inside a navigation ToC.