### PR TITLE
fix: rework text document justification

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
           <li>
             <a href="#tdpl">Theorems, Definitions and Proofs</a>
             <ol>
-              <li><a href="#proofs-theorems">Proofs & Theorems</a></li>
+              <li><a href="#proofs-theorems">Proofs & Theo&shy;rems</a></li>
               <li><a href="#lemmas">Lemmas</a></li>
               <li><a href="#definitions">Definitions</a></li>
             </ol>
@@ -64,8 +64,8 @@
           <li><a href="#text-justification">Text Justification</a></li>
           <li><a href="#table-classes">Table Classes</a>
             <ol>
-              <li><a href="#table-borders">Custom Table Borders</a></li>
-              <li><a href="#table-column-aligment">Table Column Alignment</a></li>
+              <li><a href="#table-borders">Custom Table Bor&shy;ders</a></li>
+              <li><a href="#table-column-aligment">Table Column Align&shy;ment</a></li>
             </ol>
           </li>
           <li><a href="#auto-hyphenation">Automatic Hyphenation</a></li>
@@ -145,7 +145,7 @@
   &lt;p&gt;...&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 
-      <h3 id="tdpl">Theorems, Definitions, Lemmas and Proofs</h3>
+      <h3 id="tdpl">Theorems, Definitions, Lem&shy;mas and Proofs</h3>
       <p>
         Theorems, definitions, lemmas and proofs are supported. Just wrap your
         content in a div and add the corresponding class to the element like

--- a/index.html
+++ b/index.html
@@ -213,20 +213,21 @@
       <h3 id="text-justification">Text Justification</h3>
       <p>
         By default, text content is aligned to the left. If you want to justify the text like in
-        LaTeX documents, you can use the class <code class="language-css">text-justify</code> with
-        <code class="language-html">body</code> element.
+        LaTeX documents, you can use the class <code class="language-css">text-justify</code> on
+        the <code class="language-html">body</code> element.
       </p>
       <p>
-        It should be taken into account that some elements, like long URLs or long inline code
-        snippets can produce a quite irregular word spacing, worsening readability. It's the
-        author's responsibility to format properly this problematic elements: for example,
-        switching to a code block, moving the URLs to a separate line, inserting word break
-        opportunities or modifying the way the line breaks are inserted.
+        It is important to consider that elements such as long URLs or long inline code snippets
+        can lead to irregular word spacing, which in turn degrades readability. It's the
+        author's responsibility to format problematic elements like switching to a code block,
+        moving the URLs to a separate line, inserting word break opportunities or modifying the
+        way the line breaks are inserted.
       </p>
       <p>
-        To address the later of these methods, the class <code class="language-css">break-all</code>
-        is provided, so the browser may insert line breaks between any two characters for every word
-        inside the element to which it is applied.
+        To address the latter of these methods, the class <code class="language-css">break-all</code>
+        can be used. When applied to an element, the browser is allowed to insert line breaks at any point
+        between two characters. Keep in mind that this does not preserve whole words, so it is
+        recommended to use it only when necessary.
       </p>
       <h3 id="table-classes">Table Classes</h3>
       <h4 id="table-borders">Custom Table Borders</h4>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="prism/prism.css" />
 </head>
 
-<body id="top">
+<body id="top" class="text-justify">
   <header>
     <h1><span class="latex">L<span>a</span>T<span>e</span>X</span>.css</h1>
     <p class="author">
@@ -61,6 +61,7 @@
             </ol>
           </li>
           <li><a href="#paragraphs">Paragraphs</a></li>
+          <li><a href="#text-justification">Text Justification</a></li>
           <li><a href="#table-classes">Table Classes</a>
             <ol>
               <li><a href="#table-borders">Custom Table Borders</a></li>
@@ -99,9 +100,8 @@
       <h2 id="getting-started">Getting Started</h2>
       <ul>
         <li>
-          Add
-          <code class="language-html">&lt;link rel="stylesheet"
-              href="https://latex.vercel.app/style.css"&gt;</code>
+          Add the line
+          <pre><code class="language-html break-all">&lt;link rel="stylesheet" href="https://latex.vercel.app/style.css"&gt;</code></pre>
           to the <code class="language-html">&lt;head&gt;</code> of your website or install the
           package using <code>npm install latex.css</code>.
         </li>
@@ -210,6 +210,24 @@
         To avoid first line indentation of some specific paragraph, the class <code>no-indent</code>
         can be used.</p>
       <pre><code class="language-html">&lt;p class="no-indent"&gt;...&lt;/p&gt;</code></pre>
+      <h3 id="text-justification">Text Justification</h3>
+      <p>
+        By default, text content is aligned to the left. If you want to justify the text like in
+        LaTeX documents, you can use the class <code class="language-css">text-justify</code> with
+        <code class="language-html">body</code> element.
+      </p>
+      <p>
+        It should be taken into account that some elements, like long URLs or long inline code
+        snippets can produce a quite irregular word spacing, worsening readability. It's the
+        author's responsibility to format properly this problematic elements: for example,
+        switching to a code block, moving the URLs to a separate line, inserting word break
+        opportunities or modifying the way the line breaks are inserted.
+      </p>
+      <p>
+        To address the later of these methods, the class <code class="language-css">break-all</code>
+        is provided, so the browser may insert line breaks between any two characters for every word
+        inside the element to which it is applied.
+      </p>
       <h3 id="table-classes">Table Classes</h3>
       <h4 id="table-borders">Custom Table Borders</h4>
       <p>
@@ -644,13 +662,13 @@
       <div class="footnotes">
         <p id="fn1">
           1. From
-          <a
+          <a class="break-all"
             href="https://www.math.brown.edu/~res/MFS/handout8.pdf">https://www.math.brown.edu/~res/MFS/handout8.pdf</a>.
           <a href="#ref1" title="Jump back to footnote 1 in the text.">↩</a>
         </p>
         <p id="fn2">
           2. “Definition.” Merriam-Webster.com Dictionary, Merriam-Webster,
-          <a
+          <a class="break-all"
             href="https://www.merriam-webster.com/dictionary/definition">https://www.merriam-webster.com/dictionary/definition</a>.
           Accessed 18 May. 2020.
           <a href="#ref2" title="Jump back to footnote 2 in the text.">↩</a>

--- a/prism/prism.css
+++ b/prism/prism.css
@@ -92,6 +92,10 @@ pre[class*='language-'] {
   white-space: normal;
 }
 
+:not(pre) > code[class*='language-'].break-all {
+  word-break: break-all;
+}
+
 .token.comment,
 .token.prolog,
 .token.doctype,

--- a/style.css
+++ b/style.css
@@ -181,6 +181,11 @@ body.libertinus {
   font-family: 'Libertinus', Georgia, Cambria, 'Times New Roman', Times, serif;
 }
 
+/* Justify all text in the document */
+body.text-justify {
+  text-align: justify;
+}
+
 body {
   font-family: 'Latin Modern', Georgia, Cambria, 'Times New Roman', Times, serif;
   line-height: 1.8;
@@ -204,9 +209,7 @@ body {
   -moz-hyphens: auto;
 }
 
-/* Justify all paragraphs */
 p {
-  text-align: justify;
   margin-top: 1rem;
 }
 
@@ -245,6 +248,15 @@ a:visited {
 a:focus {
   outline-offset: 2px;
   outline: 2px solid var(--link-focus-outline);
+}
+
+/* Allow line breaks between any two characters */
+.break-all {
+  /*
+    NOTE: Whith `break-all` value no hyphens are shown, even if the word breaks
+    at a hyphenation point
+  */
+  word-break: break-all;
 }
 
 /* Make images easier to work with */
@@ -557,6 +569,8 @@ dl dd {
   margin-right: -20vw;
   margin-bottom: 1em;
   text-indent: 0;
+  /* Right sidenotes explicitly aligned to left for wide screens */
+  text-align: left;
 }
 
 .sidenote.left {
@@ -564,6 +578,14 @@ dl dd {
   margin-left: -20vw;
   margin-bottom: 1em;
   text-indent: 0;
+  /* Left sidenotes explicitly aligned to right for wide screens */
+  text-align: right;
+}
+
+/* Justify all sidenotes for wide screens when `text-justify` class is used */
+body.text-justify .sidenote,
+body.text-justify .sidenote.left {
+    text-align: justify;
 }
 
 /* (WIP) add border when a sidenote is clicked on */
@@ -634,6 +656,17 @@ input.sidenote-toggle {
     clear: both;
     width: 95%;
   }
+
+  /* All sidenotes explicitly aligned to left for narrow screens */
+  .sidenote-toggle:checked + .sidenote.left {
+    text-align: left;
+  }
+
+  /* Justify all sidenotes for narrow screens when `text-justify` class is used */
+  body.text-justify .sidenote-toggle:checked + .sidenote.left {
+    text-align: justify;
+  }
+
   /* tweak indentation of sidenote inside a blockquote */
   blockquote .sidenote {
     margin-right: -25vw;
@@ -641,9 +674,8 @@ input.sidenote-toggle {
   }
 }
 
-/* Make footnote text smaller and left align it (looks bad with long URLs) */
+/* Make footnote text smaller */
 .footnotes p {
-  text-align: left;
   line-height: 1.5;
   font-size: 85%;
   margin-bottom: 0.4rem;

--- a/style.css
+++ b/style.css
@@ -181,8 +181,7 @@ body.libertinus {
   font-family: 'Libertinus', Georgia, Cambria, 'Times New Roman', Times, serif;
 }
 
-/* Justify all text in the document */
-body.text-justify {
+.text-justify {
   text-align: justify;
 }
 


### PR DESCRIPTION
- All text aligned to left by default
- Add `text-justify` CSS class to apply to the `body` element
- (doc) Justify the main doc file `index.html`.
- (doc) Reformat the code snippet for the first point of "Getting Started"
  section: code-inline -> code-block
- Sidenotes behavior changes:
  - Right sidenotes explicitly aligned to left by default for `@media (width >= 1050px)`
  - Left sidenotes explicitly aligned to right by default for `@media (width >= 1050px)`
  - All sidenotes aligned to left by default for `@media (width <= 1050px)`
  - All sidenotes justified for `body.text-justify`
- Add `break-all` class to allow line breaks between any two characters
- Justify the footnotes text (previously left-aligned by default while
  the main text was justified), when `body.text-justify` is used
- (doc) Add `break-all` class to footnotes links to improve word spacing
- Add some soft hyphens to improve the justification
