### PR TITLE
fix: add missing polish translations

### DIFF
--- a/lang/pl.css
+++ b/lang/pl.css
@@ -2,3 +2,5 @@
 :lang(pl) .lemma::before { content: 'Lemat ' counter(theorem) '. ' !important; }
 :lang(pl) .proof::before { content: 'Dowód. ' attr(title) !important; }
 :lang(pl) .definition::before { content: 'Definicja ' counter(definition) '. ' !important; }
+:lang(pl) caption::before { content: 'Tabela ' counter(caption) '. ' !important; }
+:lang(pl) figcaption::before { content: 'Rysunek ' counter(figcaption) '. ' !important; }


### PR DESCRIPTION
Add missing translations for `Figure` and `Table` in Polish.